### PR TITLE
Update protocol classes to use Google style

### DIFF
--- a/templates/DeviceDiscovery.java
+++ b/templates/DeviceDiscovery.java
@@ -17,15 +17,12 @@
  * @author: Tyler Cox, Dell
  * @version: 1.0.0
  *******************************************************************************/
+
 package ${Package}.${Protocol path};
 
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import ${Package}.data.DeviceStore;
 import ${Package}.data.WatcherStore;
 import ${Package}.domain.ScanList;
@@ -37,104 +34,108 @@ import org.edgexfoundry.domain.meta.Protocol;
 import org.edgexfoundry.domain.meta.ProvisionWatcher;
 import org.edgexfoundry.support.logging.client.EdgeXLogger;
 import org.edgexfoundry.support.logging.client.EdgeXLoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 @Service
 public class DeviceDiscovery {
-	private final static EdgeXLogger logger = EdgeXLoggerFactory.getEdgeXLogger(DeviceDiscovery.class);
+  private static final EdgeXLogger logger =
+      EdgeXLoggerFactory.getEdgeXLogger(DeviceDiscovery.class);
 
-	@Autowired
-	private WatcherStore watchers;
-	
-	@Autowired
-	private DeviceStore devices;
-	
-	//TODO Generate protocol dynamically
-	private Protocol protocol = Protocol.MAC;
+  @Autowired
+  private WatcherStore watchers;
 
-	private ProvisionWatcher deviceMatches(Map<String, String> device) {
-		for (ProvisionWatcher watcher: watchers.getWatchers()) {
-			Map<String, String> identifiers = watcher.getIdentifiers();
-			boolean found = true;
-			
-			for (Map.Entry<String, String> entry : identifiers.entrySet())
-			{
-				Pattern p = Pattern.compile(entry.getValue());
-				Matcher m = null;
-				String fieldValue = "";
-				fieldValue = device.get(entry.getKey());
-				m = p.matcher(fieldValue);
-				
-				if(m == null) {
-					logger.error("Identifier field " + entry.getKey() + " was not found.");
-					break;
-				}
-	
-				if(m.matches()){
-					
-					found = found && true;
-				}
-				else{
-					found = false;
-					break;
-				}
-	
-			}
-			
-			if (found) {
-				logger.debug("Matching Device " + device + " found.");
-				return watcher;
-			}
-		}
-		
-		return null;
-	}
+  @Autowired
+  private DeviceStore devices;
 
-	private Device deviceExists(Map<String, String> device) {
-		return devices.getMetaDevices().stream().filter(d -> device.get("address").equals(d.getAddressable().getPath())).findFirst().orElse(null);
-	}
+  //TODO Generate protocol dynamically
+  private Protocol protocol = Protocol.MAC;
 
-	private Device createDevice(Map<String, String> device, ProvisionWatcher watcher) {
-		Device newDevice = new Device();
-		newDevice.setProfile(watcher.getProfile());
-		newDevice.setService(watcher.getService());
-		String name = device.get("name") + " " + device.get("address");
-		newDevice.setName(name);
-		Addressable addressable = createAddressable(device, name, watcher.getService().getAddressable());
-		newDevice.setAddressable(addressable);
-		newDevice.setLabels(watcher.getService().getLabels());
-		newDevice.setAdminState(AdminState.unlocked);
-		newDevice.setOperatingState(OperatingState.enabled);
-		return newDevice;
-	}
-	
-	private Addressable createAddressable(Map<String, String> device, String name, Addressable service) {
-		Addressable addressable = new Addressable(
-				name, protocol, device.get("interface"),
-				device.get("address"), service.getPort());		
-		return addressable;
-	}
-	
-	public void provision(ScanList availableList) {
-		if(availableList != null && availableList.getScan().size() > 0){
-			for (Map<String,String> device : availableList.getScan()) {
-				Device matchingDevice = deviceExists(device);
-				if (matchingDevice != null) {
-					if (matchingDevice.getOperatingState().equals(OperatingState.disabled) || devices.getDevice(matchingDevice.getName()) == null) {
-						matchingDevice.setOperatingState(OperatingState.enabled);
-						devices.add(matchingDevice);
-					}
-					continue;
-				}
-				
-				ProvisionWatcher watcher = deviceMatches(device);
-				if (watcher != null) {
-					//Provision the device
-					Device newDevice = createDevice(device, watcher);
-					devices.add(newDevice);
-				}
-			}
-		}
-		
-	}
+  private ProvisionWatcher deviceMatches(Map<String, String> device) {
+    for (ProvisionWatcher watcher: watchers.getWatchers()) {
+      Map<String, String> identifiers = watcher.getIdentifiers();
+      boolean found = true;
 
+      for (Map.Entry<String, String> entry : identifiers.entrySet()) {
+        Pattern p = Pattern.compile(entry.getValue());
+        Matcher m = null;
+        String fieldValue = "";
+        fieldValue = device.get(entry.getKey());
+        m = p.matcher(fieldValue);
+
+        if (m == null) {
+          logger.error("Identifier field " + entry.getKey() + " was not found.");
+          break;
+        }
+
+        if (m.matches()) {
+          found = found && true;
+        } else {
+          found = false;
+          break;
+        }
+      }
+
+      if (found) {
+        logger.debug("Matching Device " + device + " found.");
+        return watcher;
+      }
+    }
+
+    return null;
+  }
+
+  private Device deviceExists(Map<String, String> device) {
+    return devices.getMetaDevices().stream()
+        .filter(d -> device.get("address").equals(d.getAddressable().getPath()))
+        .findFirst().orElse(null);
+  }
+
+  private Device createDevice(Map<String, String> device, ProvisionWatcher watcher) {
+    Device newDevice = new Device();
+    newDevice.setProfile(watcher.getProfile());
+    newDevice.setService(watcher.getService());
+    String name = device.get("name") + " " + device.get("address");
+    newDevice.setName(name);
+    Addressable addressable =
+        createAddressable(device, name, watcher.getService().getAddressable());
+    newDevice.setAddressable(addressable);
+    newDevice.setLabels(watcher.getService().getLabels());
+    newDevice.setAdminState(AdminState.unlocked);
+    newDevice.setOperatingState(OperatingState.enabled);
+    return newDevice;
+  }
+
+  private Addressable createAddressable(Map<String, String> device, String name,
+      Addressable service) {
+    Addressable addressable = new Addressable(name, protocol, device.get("interface"),
+        device.get("address"), service.getPort());
+
+    return addressable;
+  }
+
+  public void provision(ScanList availableList) {
+    if (availableList != null && availableList.getScan().size() > 0) {
+      for (Map<String,String> device : availableList.getScan()) {
+        Device matchingDevice = deviceExists(device);
+
+        if (matchingDevice != null) {
+          if (matchingDevice.getOperatingState().equals(OperatingState.disabled)
+              || devices.getDevice(matchingDevice.getName()) == null) {
+            matchingDevice.setOperatingState(OperatingState.enabled);
+            devices.add(matchingDevice);
+          }
+
+          continue;
+        }
+
+        ProvisionWatcher watcher = deviceMatches(device);
+        if (watcher != null) {
+          // Provision the device
+          Device newDevice = createDevice(device, watcher);
+          devices.add(newDevice);
+        }
+      }
+    }
+  }
 }

--- a/templates/ObjectTransform.java
+++ b/templates/ObjectTransform.java
@@ -17,112 +17,121 @@
  * @author: Tyler Cox, Dell
  * @version: 1.0.0
  *******************************************************************************/
+
 package ${Package}.${Protocol path};
 
 import java.math.BigInteger;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import ${Package}.data.ObjectStore;
 import org.edgexfoundry.domain.meta.PropertyValue;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 @Service
 public class ObjectTransform {
 
-	@Autowired
-	ObjectStore objectCache;
-	
-	// Read current value, then mask and or with the desired set
-	public String maskedValue(PropertyValue value, String val, String result) {
-		
-		BigInteger intValue = parse(value, val);
-		BigInteger resultValue = parse(value, result);
-		
-		intValue = intValue.shiftLeft(value.shift());
-		BigInteger maskedValue = resultValue.and(value.mask().not());
-		maskedValue = maskedValue.or(intValue);
-		Integer maskedVal = maskedValue.intValue();
-		
-		return String.format("%0" + value.size() + "X", maskedVal);
-	}
+  @Autowired
+  ObjectStore objectCache;
 
-	public String transform(PropertyValue value, String result) {
-		double floatValue;
-		
-		if (value.getLSB() != null) {
-			BigInteger val = parse(value, result);
-			
-			if (!value.mask().equals(BigInteger.ZERO))
-				val = val.and(value.mask()); 
-			
-			if (!value.shift().equals(0))
-				val = val.shiftRight(value.shift());
-			
-			if (value.getSigned() && val.bitLength()==(value.size()*4)) {
-				BigInteger complement = new BigInteger(new String(new char[value.size()]).replace("\0", "F"),16);
-				val = val.subtract(complement);
-			}
-			
-			if (!objectCache.getTransformData()) {
-				int intValue = val.intValue();
-				return String.valueOf(intValue);
-			}
-			
-			floatValue = val.doubleValue();
-		} else {
-			floatValue = Float.parseFloat(result);
-		}
-		
-		if (!value.base().equals(0))
-			floatValue = Math.pow(value.base(), floatValue);
-		floatValue = floatValue * value.scale();
-		floatValue = floatValue + value.offset();
-		
-		if (value.getType().toLowerCase().equals("f") || value.getType().toLowerCase().equals("float"))
-			return String.valueOf(floatValue);
-		return String.valueOf(Math.round(floatValue));
-	}
-	
-	public BigInteger parse(PropertyValue value, String result) {
-		BigInteger val = BigInteger.ZERO;
-		
-		if(result.startsWith("0x"))
-			result = result.substring(2, result.length());
-		else
-			result = String.format("%0" + value.size() + "X", Integer.decode(result));
-		
-		Integer word = value.word() * 2;
-		
-		if (word > value.size())
-			word = value.size();
-		
-		for (int i = 0; i < result.length()/word; i++) {
-			Integer start = i*word;
-			Integer finish = (i+1)*word;
-			BigInteger thisword = BigInteger.ZERO;
-		
-			for (int j = 0; j < word/2; j++) {
-				if (value.LSB()) {
-					Integer index = finish - j * 2;
-					Integer intval = Integer.decode("0x"+result.substring(index-2,index));
-					thisword = BigInteger.valueOf(intval).add(thisword.shiftLeft(8));
-				} else {
-					Integer index = start + j * 2;
-					Integer intval = Integer.decode("0x"+result.substring(index,index+2));
-					thisword = BigInteger.valueOf(intval).add(thisword.shiftLeft(8));
-				}
-			}
-			
-			val = thisword.add(val.shiftLeft(word*4));				
-		}
-		
-		return val;
-	}
-	
-	public String format(PropertyValue value, String arg) {
-		BigInteger intValue = parse(value, arg);
-		Integer val = intValue.intValue();
-		return String.format("0x%0" + value.size() + "X", val);
-	}
+  // Read current value, then mask and or with the desired set
+  public String maskedValue(PropertyValue value, String val, String result) {
+
+    BigInteger intValue = parse(value, val);
+    BigInteger resultValue = parse(value, result);
+
+    intValue = intValue.shiftLeft(value.shift());
+    BigInteger maskedValue = resultValue.and(value.mask().not());
+    maskedValue = maskedValue.or(intValue);
+    Integer maskedVal = maskedValue.intValue();
+
+    return String.format("%0" + value.size() + "X", maskedVal);
+  }
+
+  public String transform(PropertyValue value, String result) {
+    double floatValue;
+
+    if (value.getLSB() != null) {
+      BigInteger val = parse(value, result);
+
+      if (!value.mask().equals(BigInteger.ZERO)) {
+        val = val.and(value.mask());
+      }
+
+      if (!value.shift().equals(0)) {
+        val = val.shiftRight(value.shift());
+      }
+
+      if (value.getSigned() && val.bitLength() == (value.size() * 4)) {
+        BigInteger complement =
+            new BigInteger(new String(new char[value.size()]).replace("\0", "F"), 16);
+        val = val.subtract(complement);
+      }
+
+      if (!objectCache.getTransformData()) {
+        int intValue = val.intValue();
+        return String.valueOf(intValue);
+      }
+
+      floatValue = val.doubleValue();
+    } else {
+      floatValue = Float.parseFloat(result);
+    }
+
+    if (!value.base().equals(0)) {
+      floatValue = Math.pow(value.base(), floatValue);
+    }
+
+    floatValue = floatValue * value.scale();
+    floatValue = floatValue + value.offset();
+
+    if (value.getType().toLowerCase().equals("f")
+        || value.getType().toLowerCase().equals("float")) {
+      return String.valueOf(floatValue);
+    }
+
+    return String.valueOf(Math.round(floatValue));
+  }
+
+  public BigInteger parse(PropertyValue value, String result) {
+    BigInteger val = BigInteger.ZERO;
+
+    if (result.startsWith("0x")) {
+      result = result.substring(2, result.length());
+    } else {
+      result = String.format("%0" + value.size() + "X", Integer.decode(result));
+    }
+
+    Integer word = value.word() * 2;
+
+    if (word > value.size()) {
+      word = value.size();
+    }
+
+    for (int i = 0; i < result.length() / word; i++) {
+      Integer start = i * word;
+      Integer finish = (i + 1) * word;
+      BigInteger thisword = BigInteger.ZERO;
+
+      for (int j = 0; j < word / 2; j++) {
+        if (value.LSB()) {
+          Integer index = finish - j * 2;
+          Integer intval = Integer.decode("0x" + result.substring(index - 2, index));
+          thisword = BigInteger.valueOf(intval).add(thisword.shiftLeft(8));
+        } else {
+          Integer index = start + j * 2;
+          Integer intval = Integer.decode("0x" + result.substring(index, index + 2));
+          thisword = BigInteger.valueOf(intval).add(thisword.shiftLeft(8));
+        }
+      }
+
+      val = thisword.add(val.shiftLeft(word * 4));
+    }
+
+    return val;
+  }
+
+  public String format(PropertyValue value, String arg) {
+    BigInteger intValue = parse(value, arg);
+    Integer val = intValue.intValue();
+    return String.format("0x%0" + value.size() + "X", val);
+  }
 }

--- a/templates/ProtocolDriver.java
+++ b/templates/ProtocolDriver.java
@@ -17,15 +17,12 @@
  * @author: Tyler Cox, Dell
  * @version: 1.0.0
  *******************************************************************************/
+
 package ${Package}.${Protocol path};
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import ${Package}.data.DeviceStore;
 import ${Package}.data.ObjectStore;
 import ${Package}.data.ProfileStore;
@@ -38,91 +35,100 @@ import org.edgexfoundry.domain.meta.ResourceOperation;
 import ${Package}.handler.${Protocol name}Handler;
 import org.edgexfoundry.support.logging.client.EdgeXLogger;
 import org.edgexfoundry.support.logging.client.EdgeXLoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 @Service
 public class ${Protocol name}Driver {
 
-	private final static EdgeXLogger logger = EdgeXLoggerFactory.getEdgeXLogger(${Protocol name}Driver.class);
-	
-	@Autowired
-	ProfileStore profiles;
-	
-	@Autowired
-	DeviceStore devices;
-	
-	@Autowired
-	ObjectStore objectCache;
-	
-	@Autowired
-	${Protocol name}Handler handler;
-	
-	public ScanList discover() {
-		ScanList scan = new ScanList();
-		
-		// TODO 4: [Optional] For discovery enabled device services:
-		// Replace with ${Protocol name} specific discovery mechanism
-		// TODO 5: [Required] Remove next code block if discovery is not used
-		for(int i = 0; i < 10; i++) {
-			Map<String, String> identifiers = new HashMap<>();
-			identifiers.put("name", String.valueOf(i));
-			identifiers.put("address", "02:01:00:11:12:1" + String.valueOf(i));
-			identifiers.put("interface", "default");
-			scan.add(identifiers);
-		}
-		
-		return scan;
-	}
-	
-	// operation is get or set
-	// Device to be written to
-	// ${Protocol name} Object to be written to
-	// value is string to be written or null
-	public void process(ResourceOperation operation, Device device, ${Protocol name}Object object, String value, String transactionId, String opId) {
-		String result = "";
-		
-		// TODO 2: [Optional] Modify this processCommand call to pass any additional required metadata from the profile to the driver stack
-		result = processCommand(operation.getOperation(), device.getAddressable(), object.getAttributes(), value);
-		
-		objectCache.put(device, operation, result);
-		handler.completeTransaction(transactionId, opId, objectCache.getResponses(device, operation));
-	}
+  private static final EdgeXLogger logger =
+      EdgeXLoggerFactory.getEdgeXLogger(${Protocol name}Driver.class);
 
-	// Modify this function as needed to pass necessary metadata from the device and its profile to the driver interface
-	public String processCommand(String operation, Addressable addressable, ${Protocol name}Attribute attributes, String value) {
-		String address = addressable.getPath();
-		String intface = addressable.getAddress();
-		logger.debug("ProcessCommand: " + operation + ", interface: " + intface + ", address: " + address + ", attributes: " + attributes + ", value: " + value );
-		String result = ""; 
-		
-		// TODO 1: [Required] ${Protocol name} stack goes here, return the raw value from the device as a string for processing
-		if (operation.toLowerCase().equals("get")) {
-			Random rand = new Random();
-			result = Float.toString(rand.nextFloat()*100);
-		} else {
-			result = value;
-		}
-		
-		return result;
-	}
+  @Autowired
+  ProfileStore profiles;
 
-	public void initialize() {
-		// TODO 3: [Optional] Initialize the interface(s) here if necessary, runs once on service startup
-		
-	}
-	
-	public void disconnectDevice(Addressable address) {
-		// TODO 6: [Optional] Disconnect devices here using driver level operations
-		
-	}
-	
-	@SuppressWarnings("unused")
-	private void receive() {
-		// TODO 7: [Optional] Fill with your own implementation for handling asynchronous data from the driver layer to the device service
-		Device device = null;
-		String result = "";
-		ResourceOperation operation = null;		
-		
-		objectCache.put(device, operation, result);
-	}
+  @Autowired
+  DeviceStore devices;
 
+  @Autowired
+  ObjectStore objectCache;
+
+  @Autowired
+  ${Protocol name}Handler handler;
+
+  public ScanList discover() {
+    ScanList scan = new ScanList();
+
+    // TODO 4: [Optional] For discovery enabled device services:
+    // Replace with ${Protocol name} specific discovery mechanism
+    // TODO 5: [Required] Remove next code block if discovery is not used
+    for (int i = 0; i < 10; i++) {
+      Map<String, String> identifiers = new HashMap<>();
+      identifiers.put("name", String.valueOf(i));
+      identifiers.put("address", "02:01:00:11:12:1" + String.valueOf(i));
+      identifiers.put("interface", "default");
+      scan.add(identifiers);
+    }
+
+    return scan;
+  }
+
+  // operation is get or set
+  // Device to be written to
+  // ${Protocol name} Object to be written to
+  // value is string to be written or null
+  public void process(ResourceOperation operation, Device device, ${Protocol name}Object object,
+      String value, String transactionId, String opId) {
+    String result = "";
+
+    // TODO 2: [Optional] Modify this processCommand call to pass any additional required metadata
+    // from the profile to the driver stack
+    result = processCommand(operation.getOperation(), device.getAddressable(),
+        object.getAttributes(), value);
+
+    objectCache.put(device, operation, result);
+    handler.completeTransaction(transactionId, opId, objectCache.getResponses(device, operation));
+  }
+
+  // Modify this function as needed to pass necessary metadata from the device and its profile to
+  // the driver interface
+  public String processCommand(String operation, Addressable addressable,
+      ${Protocol name}Attribute attributes, String value) {
+    String address = addressable.getPath();
+    String intface = addressable.getAddress();
+    logger.debug("ProcessCommand: " + operation + ", interface: " + intface + ", address: "
+        + address + ", attributes: " + attributes + ", value: " + value);
+    String result = "";
+
+    // TODO 1: [Required] ${Protocol name} stack goes here, return the raw value from the device
+    // as a string for processing
+    if (operation.toLowerCase().equals("get")) {
+      Random rand = new Random();
+      result = Float.toString(rand.nextFloat() * 100);
+    } else {
+      result = value;
+    }
+
+    return result;
+  }
+
+  public void initialize() {
+    // TODO 3: [Optional] Initialize the interface(s) here if necessary, runs once on
+    // service startup
+  }
+
+  public void disconnectDevice(Addressable address) {
+    // TODO 6: [Optional] Disconnect devices here using driver level operations
+  }
+
+  @SuppressWarnings("unused")
+  private void receive() {
+    // TODO 7: [Optional] Fill with your own implementation for handling asynchronous
+    // data from the driver layer to the device service
+    Device device = null;
+    String result = "";
+    ResourceOperation operation = null;
+
+    objectCache.put(device, operation, result);
+  }
 }


### PR DESCRIPTION
Update the template .protocol classes to use the Google Java style guide:

https://google.github.io/styleguide/javaguide.html

Which can checked via checkstyle (http://checkstyle.sourceforge.net/) like this:

$ java -jar ./checkstyle-8.0-all.jar -c /google_checks.xml

This change doesn't resolve javadoc errors, nor does it include a fix for errors caused by the ${} string
replacement syntax. These will be fixed in subsequent commits.

Tested by generating a new DS, and also copied modified classes into device-sdk to verify the build.

Signed-off-by: Tony Espy espy@canonical.com